### PR TITLE
Correct demonstration results

### DIFF
--- a/case_example_mapping/dict_to_case.py
+++ b/case_example_mapping/dict_to_case.py
@@ -34,7 +34,7 @@ def main() -> None:
         sys.exit(1)
     output_path: str = sys.argv[1]
 
-    # Add an uco-observable:ObservableObject to the graph
+    # Add a uco-identity:Organization to the graph
     case["@graph"].append(
         {
             "@id": "kb:organization-2b3b98e2-aea2-4270-876a-7f9917623cb6",

--- a/case_example_mapping/rdf_to_case.py
+++ b/case_example_mapping/rdf_to_case.py
@@ -1,7 +1,7 @@
 import sys
 
 from rdflib import Graph, Literal, Namespace, URIRef
-from rdflib.namespace import XSD
+from rdflib.namespace import RDF, XSD
 
 
 def main() -> None:
@@ -22,11 +22,28 @@ def main() -> None:
         "https://ontology.unifiedcyberontology.org/uco/core/"
     )
 
+    ns_kb: Namespace = Namespace("http://example.org/kb/")
+
+    # Define an individual.
+    # RDFLib Namespace provides two ways to create a URIRef of the
+    # namespace as a string-prefix concatenated with an argument:
+    # * The . operator.
+    # * The [] operator.
+    iri_my_organization = ns_kb["organization-b1534f63-b1c3-4b5c-a937-cbe7077571f2"]
+
     g.add(
         (
+            iri_my_organization,
+            RDF.type,
             URIRef(
                 "https://ontology.unifiedcyberontology.org/uco/identity/Organization"
             ),
+        )
+    )
+
+    g.add(
+        (
+            iri_my_organization,
             ns_core.name,
             Literal("Cyber Domain Ontology", datatype=XSD.string),
         )

--- a/tests/case_output_test.py
+++ b/tests/case_output_test.py
@@ -1,7 +1,8 @@
 import os
 import unittest
+from typing import Set
 
-from rdflib import Graph
+from rdflib import Graph, URIRef
 
 
 class CASEOutputTests(unittest.TestCase):
@@ -35,3 +36,43 @@ class CASEOutputTests(unittest.TestCase):
                 self.assertGreaterEqual(
                     len(g), 1, f"There were no triples found in file: {file}"
                 )
+
+    def test_organization_iri_found(self) -> None:
+        """
+        Identifies all CASE graph files within the ./output directory and ensures they contain a graph individual that:
+
+        * Is, by RDF class-membership, a UCO organization; and
+        * Has the UCO name "Cyber Domain Ontology".
+
+        When adapting this template repository, this test should be replaced.
+        """
+        files_tested: int = 0
+        source_directory: str = "./output"
+        query = """\
+PREFIX uco-core: <https://ontology.unifiedcyberontology.org/uco/core/>
+PREFIX uco-identity: <https://ontology.unifiedcyberontology.org/uco/identity/>
+SELECT ?nOrganization
+WHERE {
+  ?nOrganization
+    a uco-identity:Organization ;
+    uco-core:name "Cyber Domain Ontology" ;
+    .
+}
+"""
+        for file in os.listdir(source_directory):
+            if not (file.endswith(".json") or file.endswith(".jsonld")):
+                continue
+            files_tested += 1
+
+            computed: Set[URIRef] = set()
+
+            g: Graph = Graph()
+            g.parse(os.path.join(source_directory, file))
+            for result in g.query(query):
+                # Graph.query for a SELECT query returns a tuple, with
+                # member count as long as the number of bound variables.
+                computed.add(result[0])
+            self.assertEqual(
+                1, len(computed), f"Organization was not found in file: {file}"
+            )
+        self.assertGreaterEqual(files_tested, 0, "No output files were tested.")


### PR DESCRIPTION
This patch series includes a code correction in the RDF-based template, and adds a SPARQL query (meant to be replaced by adopters) that verifies not only that a generated graph has data, but it has a certain pattern of expected data.