### PR TITLE
Switch Action to CASE 1.0

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -53,7 +53,7 @@ jobs:
 
     # Test the output files to confirm they're both conformant to the CASE Ontology
     - name: CASE Validation
-      uses: kchason/case-validation-action@v2.2
+      uses: kchason/case-validation-action@v2.3
       with:
         case-path: ./output/
-        case-version: "case-0.7.0"
+        case-version: "case-1.0.0"


### PR DESCRIPTION
Updates the CASE Validation [GitHub Action](https://github.com/kchason/case-validation-action) to point to CASE 1.0.0 instead of 0.7.0.