### PR TITLE
Replace setup.py

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -40,8 +40,7 @@ jobs:
     # the CASE outputs
     - name: Build CASE
       run: |
-        pip install setuptools
-        python setup.py install
+        pip install .
         mkdir -p ./output/
         case_from_dict ./output/dict-case.json
         case_from_rdf ./output/rdf-case.json


### PR DESCRIPTION
Reference article noted by `SetuptoolsDeprecationWarning` from Action log.

References:
* https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html#summary